### PR TITLE
fix: replace `test` command by bash builtin test

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         gh pr view --json body -q ".body" $MERGE_QUEUE_PR_URL | sed -n -e '/```yaml/,/```/p' | sed -e '1d;$d' | yq '.pull_requests[]|.number' | while read pr_number ; do
           gh pr view --json labels -q '.labels[]|.name' ${REPOSITORY_URL}/pull/$pr_number | while read label ; do
-            if [ -z "$labels" -o ",$labels," =~ ",$label," ]; then
+            if [[ -z "$labels" ]] || [[ ",$labels," =~ ",$label," ]]; then
               gh pr edit --add-label "$label" $MERGE_QUEUE_PR_URL
             if
           done


### PR DESCRIPTION
This ensures the check doesn't depend on OS `test` command. MacOS or old ubuntu may not support `-o` and regex with `test` command.
