### PR TITLE
add support for "additional-labels"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ jobs:
         uses: Mergifyio/gha-mergify-merge-queue-labels-copier
         with:
           labels: docker
+          additional-labels: merge-queue-pr
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Comma separated list of labels to copy (all if empty)'
     required: true
     default: ''
+  additional-labels:
+    description: 'Comma separated list of additional labels to add to the merge queue PR'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -15,11 +19,15 @@ runs:
         REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
         MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
         GH_TOKEN: ${{ github.token }}
+        ADDITIONAL_LABELS: ${{ inputs.additional-labels }}
       run: |
         gh pr view --json body -q ".body" $MERGE_QUEUE_PR_URL | sed -n -e '/```yaml/,/```/p' | sed -e '1d;$d' | yq '.pull_requests[]|.number' | while read pr_number ; do
           gh pr view --json labels -q '.labels[]|.name' ${REPOSITORY_URL}/pull/$pr_number | while read label ; do
             if [[ -z "$labels" ]] || [[ ",$labels," =~ ",$label," ]]; then
               gh pr edit --add-label "$label" $MERGE_QUEUE_PR_URL
             if
+          done
+          for additional-label in $(echo $ADDITIONAL_LABELS | sed "s/,/ /g") ; do
+            gh pr edit --add-label "$additional-label" $MERGE_QUEUE_PR_URL
           done
         done


### PR DESCRIPTION
add support for "additional-labels"
    
Signed-off-by: Niels de Vos <ndevos@ibm.com>
Signed-off-by: Rakshith R <rar@redhat.com>

We ran some tests at https://github.com/ceph/ceph-csi for the startsWith and if statement fix.

The new config "additional-labels" necessity was released since mergifyio runs only a subset of
rules on such merge queue draft prs.
Refer: https://github.com/ceph/ceph-csi/pull/3835#issuecomment-1549020177

/cc @sileht @jd @DouglasBlackwood 

<!--

## Checklists (Just for information, delete me before creating the pull requests)

- [ ]  All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ]  The code changed/added as part of this pull request must be covered with tests
- [ ]  Hotfixes must have a link to Sentry issue and the `hotfix` label
- [ ]  Features and fixes must have a link to a Linear task
- [ ]  Features must have changes in docs/
- [ ]  Features must have changes in releasenotes/notes/
- [ ]  User facing bug must have changed in releasenotes/nodes/
- [ ]  Pull request must have been reviewed by at least one core reviewer
- [ ]  No pending `requested changes`
- [ ]  No `unresolved threads`
- [ ]  Change that requires manual deployment steps or deployment monitoring requires `manual merge` label until the author is ready to do the deployment.

-->
