### PR TITLE
Arguments for startsWith() should be reversed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Copying labels
       shell: bash
-      if: startsWith('mergify/merge-queue/', github.head_ref)
+      if: startsWith(github.head_ref, 'mergify/merge-queue/')
       env:
         REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
         MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}


### PR DESCRIPTION
See-also: https://docs.github.com/en/actions/learn-github-actions/expressions


<!--

## Checklists (Just for information, delete me before creating the pull requests)

- [ ]  All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ]  The code changed/added as part of this pull request must be covered with tests
- [ ]  Hotfixes must have a link to Sentry issue and the `hotfix` label
- [ ]  Features and fixes must have a link to a Linear task
- [ ]  Features must have changes in docs/
- [ ]  Features must have changes in releasenotes/notes/
- [ ]  User facing bug must have changed in releasenotes/nodes/
- [ ]  Pull request must have been reviewed by at least one core reviewer
- [ ]  No pending `requested changes`
- [ ]  No `unresolved threads`
- [ ]  Change that requires manual deployment steps or deployment monitoring requires `manual merge` label until the author is ready to do the deployment.

-->
