### PR TITLE
fix `additional-label` invalid shell syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
               gh pr edit --add-label "$label" $MERGE_QUEUE_PR_URL
             fi
           done
-          for additional-label in $(echo $ADDITIONAL_LABELS | sed "s/,/ /g") ; do
-            gh pr edit --add-label "$additional-label" $MERGE_QUEUE_PR_URL
+          for additional_label in $(echo $ADDITIONAL_LABELS | sed "s/,/ /g") ; do
+            gh pr edit --add-label "$additional_label" $MERGE_QUEUE_PR_URL
           done
         done


### PR DESCRIPTION
A shell variable may not contain `-`, so `additional-label` is not a valid identifier. This causes the Action to fail with error like these:

    line 10: `additional-label': not a valid identifier

/cc @Rakshith-R
