### PR TITLE
add support for passing github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ jobs:
         with:
           labels: docker
           additional-labels: merge-queue-pr
+          repo-token: ${{ github.token }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Comma separated list of additional labels to add to the merge queue PR'
     required: false
     default: ''
+  token:
+    description: 'The GitHub token to use for API requests'
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "composite"
   steps:
@@ -18,7 +22,7 @@ runs:
       env:
         REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
         MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.token}}
         ADDITIONAL_LABELS: ${{ inputs.additional-labels }}
       run: |
         gh pr view --json body -q ".body" $MERGE_QUEUE_PR_URL | sed -n -e '/```yaml/,/```/p' | sed -e '1d;$d' | yq '.pull_requests[]|.number' | while read pr_number ; do


### PR DESCRIPTION
Currently label copier action uses default
`github.token` which uses github-actions bot
for copying labels but this does trigger
other workflows.
Therefore this commit adds support for
passing repo-token(default is still github.token)
which allows users to use another account
to copy labels and trigger other workflows.

refer: https://github.com/orgs/community/discussions/25565

Similar to https://github.com/actions/labeler/blob/main/action.yml#L5-L8

add-comment ci was not triggered here https://github.com/ceph/ceph-csi/pull/3903
https://github.com/ceph/ceph-csi/actions/runs/5257801635/workflow?pr=3903

/cc @sileht @jd @nixpanic  
