### PR TITLE
set GH_ENTERPRISE_TOKEN to have this work on enterprise GitHub environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ jobs:
         with:
           labels: docker
           additional-labels: merge-queue-pr
-          repo-token: ${{ github.token }}
+          token: ${{ github.token }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,8 @@ runs:
       env:
         REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
         MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-        GH_TOKEN: ${{ inputs.token}}
+        GH_TOKEN: ${{ inputs.token }}
+        GH_ENTERPRISE_TOKEN: ${{ inputs.token }}
         ADDITIONAL_LABELS: ${{ inputs.additional-labels }}
       run: |
         gh pr view --json body -q ".body" $MERGE_QUEUE_PR_URL | sed -n -e '/```yaml/,/```/p' | sed -e '1d;$d' | yq '.pull_requests[]|.number' | while read pr_number ; do


### PR DESCRIPTION
So I'm using this workflow on an enterprise GitHub instance that is using mergify. This was not working correctly because the gh cli was not authenticating. Looking at the [gh environment docs](https://cli.github.com/manual/gh_help_environment) the `GH_ENTERPRISE_TOKEN` environment variable needs to be set for this case. 

<!--

## Checklists (Just for information, delete me before creating the pull requests)

- [ ]  All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ]  The code changed/added as part of this pull request must be covered with tests
- [ ]  Hotfixes must have a link to Sentry issue and the `hotfix` label
- [ ]  Features and fixes must have a link to a Linear task
- [ ]  Features must have changes in docs/
- [ ]  Features must have changes in releasenotes/notes/
- [ ]  User facing bug must have changed in releasenotes/nodes/
- [ ]  Pull request must have been reviewed by at least one core reviewer
- [ ]  No pending `requested changes`
- [ ]  No `unresolved threads`
- [ ]  Change that requires manual deployment steps or deployment monitoring requires `manual merge` label until the author is ready to do the deployment.

-->
