### PR TITLE
fix: don't always copy all labels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - main
+      - devs/**
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v5.0.0
+      - name: Build 🔧 & Test 🔍
+        run: |
+          pip install pytest
+          pytest -v tests
+
+  linters:
+    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v5.0.0
+
+      - name: Actionlint
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color
+
+      - name: Shellcheck
+        run: |
+          shellcheck run.sh
+          shellcheck tests/mocks/gh
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+.pytest_cache

--- a/action.yml
+++ b/action.yml
@@ -27,15 +27,6 @@ runs:
         MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
         GH_TOKEN: ${{ inputs.token }}
         GH_ENTERPRISE_TOKEN: ${{ inputs.token }}
+        LABELS_TO_COPY: ${{ inputs.labels }}
         ADDITIONAL_LABELS: ${{ inputs.additional-labels }}
-      run: |
-        gh pr view --json body -q ".body" $MERGE_QUEUE_PR_URL | sed -n -e '/```yaml/,/```/p' | sed -e '1d;$d' | yq '.pull_requests[]|.number' | while read pr_number ; do
-          gh pr view --json labels -q '.labels[]|.name' ${REPOSITORY_URL}/pull/$pr_number | while read label ; do
-            if [[ -z "$labels" ]] || [[ ",$labels," =~ ",$label," ]]; then
-              gh pr edit --add-label "$label" $MERGE_QUEUE_PR_URL
-            fi
-          done
-          for additional_label in $(echo $ADDITIONAL_LABELS | sed "s/,/ /g") ; do
-            gh pr edit --add-label "$additional_label" $MERGE_QUEUE_PR_URL
-          done
-        done
+      run: ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -Eeo pipefail
+
+die() {
+    echo "$@"
+    exit 1;
+}
+
+[ -n "$MERGE_QUEUE_PR_URL" ] || die "MERGE_QUEUE_PR_URL is not set"
+[ -n "$REPOSITORY_URL" ] || die "REPOSITORY_URL is not set"
+
+MERGE_QUEUE_METADATA="$(gh pr view --json body -q ".body" "$MERGE_QUEUE_PR_URL" | sed -n -e "/\`\`\`yaml/,/\`\`\`/p" | sed -e '1d;$d')"
+mapfile -t PR_NUMBERS < <(echo "$MERGE_QUEUE_METADATA" | yq -r '.pull_requests[].number')
+
+echo "Copying labels from ${PR_NUMBERS[*]} to $MERGE_QUEUE_PR_URL"
+
+LABELS_TO_ADD="$ADDITIONAL_LABELS"
+
+for pr_number in "${PR_NUMBERS[@]}"; do
+
+  mapfile -t pr_labels < <(gh pr view --json labels -q '.labels[]|.name' "${REPOSITORY_URL}/pull/$pr_number")
+  echo "Found labels: ${pr_labels[*]} on PR #$pr_number"
+  for pr_label in "${pr_labels[@]}"; do
+    if [[ -z "$LABELS_TO_COPY" ]] || [[ ",$LABELS_TO_COPY," =~ ,"$pr_label", ]]; then
+      LABELS_TO_ADD="$LABELS_TO_ADD,$pr_label"
+    fi
+  done
+
+done
+
+echo "Adding labels $LABELS_TO_ADD to $MERGE_QUEUE_PR_URL"
+if [ -n "$LABELS_TO_ADD" ]; then
+    gh pr edit "$MERGE_QUEUE_PR_URL" --add-label "$LABELS_TO_ADD"
+fi

--- a/tests/mocks/gh
+++ b/tests/mocks/gh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -Eeuo pipefail
+echo "gh $*" >> "${MOCK_LOG_FILE}"
+
+cmd="$1"; shift || true
+if [[ "$cmd" != "pr" ]]; then
+  echo "Unsupported gh command: $cmd" >&2; exit 2
+fi
+
+sub="$1"; shift || true
+case "$sub" in
+  view)
+    # Body: gh pr view --json body -q ".body" "$MERGE_QUEUE_PR_URL"
+    # Labels: gh pr view --json labels -q '.labels[]|.name' "$REPO_URL/pull/<num>"
+    if [[ "${1:-}" == "--json" && "${2:-}" == "body" ]]; then
+      echo "${MERGE_QUEUE_PR_BODY:-}"
+      exit 0
+    elif [[ "${1:-}" == "--json" && "${2:-}" == "labels" ]]; then
+      last="${*:-}"; prnum="${last##*/}"
+      case "$prnum" in
+        101) printf "%s\n" bug backport ;;
+        202) printf "%s\n" docs ;;
+        303) printf "%s\n" bar ;;
+        *) echo "Unknown PR #$prnum" >&2; exit 2 ;;
+      esac
+      exit 0
+    else
+      echo "Unexpected gh pr view invocation: gh pr view $*" >&2
+      exit 2
+    fi
+    ;;
+  edit)
+    url="$1"; shift || true
+    if [[ "${1:-}" != "--add-label" ]]; then
+      echo "Expected --add-label arg, got: $1" >&2; exit 2
+    fi
+    shift || true
+    labels="$1"
+    echo "EDIT|URL=$url|LABELS=$labels" >> "${MOCK_LOG_FILE}"
+    ;;
+  *)
+    echo "Unsupported gh pr subcommand: $sub" >&2; exit 2
+    ;;
+esac

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,141 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Hardcoded locations relative to this file
+THIS_DIR = Path(__file__).parent
+SCRIPT_PATH = (THIS_DIR.parent / "run.sh").resolve()
+MOCK_PATH = (THIS_DIR / "mocks").resolve()
+
+
+def build_body(pr_nums):
+    lines = ["intro", "```yaml", "pull_requests:"]
+    lines += [f"  - number: {n}" for n in pr_nums]
+    lines += ["```", "outro"]
+    return "\n".join(lines)
+
+
+def print_stdx(proc):
+    # Print captured output to help debugging
+    print(f"EXIT CODE: {proc.returncode}")
+    print("------ STDOUT ------")
+    print(proc.stdout or "<empty>")
+    print("------ STDERR ------")
+    print(proc.stderr or "<empty>")
+    print("--------------------")
+
+
+@pytest.mark.parametrize(
+    "prs,addl,ltc,expected",
+    [
+        pytest.param([101], None, None, ",bug,backport", id="ONE|no-addl|copy=ALL"),
+        pytest.param(
+            [101], "EXTRA", None, "EXTRA,bug,backport", id="ONE|addl=EXTRA|copy=ALL"
+        ),
+        pytest.param(
+            [101], None, "backport", ",backport", id="ONE|no-addl|copy=backport"
+        ),
+        pytest.param(
+            [101],
+            "EXTRA",
+            "backport",
+            "EXTRA,backport",
+            id="ONE|addl=EXTRA|copy=backport",
+        ),
+        pytest.param(
+            [101],
+            None,
+            "backport,bar,zzz",
+            ",backport",
+            id="ONE|no-addl|copy=backport,bar,zzz",
+        ),
+        pytest.param(
+            [101],
+            "EXTRA",
+            "backport,bar,zzz",
+            "EXTRA,backport",
+            id="ONE|addl=EXTRA|copy=backport,bar,zzz",
+        ),
+        pytest.param(
+            [101, 202, 303],
+            None,
+            None,
+            ",bug,backport,docs,bar",
+            id="THREE|no-addl|copy=ALL",
+        ),
+        pytest.param(
+            [101, 202, 303],
+            "EXTRA",
+            None,
+            "EXTRA,bug,backport,docs,bar",
+            id="THREE|addl=EXTRA|copy=ALL",
+        ),
+        pytest.param(
+            [101, 202, 303],
+            None,
+            "backport",
+            ",backport",
+            id="THREE|no-addl|copy=backport",
+        ),
+        pytest.param(
+            [101, 202, 303],
+            "EXTRA",
+            "backport",
+            "EXTRA,backport",
+            id="THREE|addl=EXTRA|copy=backport",
+        ),
+        pytest.param(
+            [101, 202, 303],
+            None,
+            "backport,bar,zzz",
+            ",backport,bar",
+            id="THREE|no-addl|copy=backport,bar,zzz",
+        ),
+        pytest.param(
+            [101, 202, 303],
+            "EXTRA",
+            "backport,bar,zzz",
+            "EXTRA,backport,bar",
+            id="THREE|addl=EXTRA|copy=backport,bar,zzz",
+        ),
+    ],
+)
+def test_matrix(prs, addl, ltc, expected, monkeypatch, tmp_path):
+    workdir = Path(tmp_path)
+    logfile = workdir / "gh_calls.log"
+    logfile.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("PATH", f"{MOCK_PATH}:{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("MERGE_QUEUE_PR_URL", "https://example.com/repo/pull/9999")
+    monkeypatch.setenv("REPOSITORY_URL", "https://example.com/repo")
+    monkeypatch.setenv("MOCK_LOG_FILE", str(logfile))
+    monkeypatch.setenv("MERGE_QUEUE_PR_BODY", build_body(prs))
+
+    if addl is not None:
+        monkeypatch.setenv("ADDITIONAL_LABELS", addl)
+
+    if ltc is not None:
+        monkeypatch.setenv("LABELS_TO_COPY", ltc)
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT_PATH)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.getcwd(),
+        text=True,
+    )
+
+    if proc.returncode != 0:
+        print_stdx(proc)
+
+    assert proc.returncode == 0
+
+    edits = [ln for ln in logfile.read_text().splitlines() if ln.startswith("EDIT|")]
+    got = edits[-1].split("LABELS=", 1)[1] if edits else ""
+
+    if got != expected:
+        print_stdx(proc)
+
+    assert got == expected


### PR DESCRIPTION
This rewrite the action that never worked when "labels:" was set.

This adds testing to the script to avoid future issues.

Fixes MRGFY-5851